### PR TITLE
インストール関連や cleanup スクリプトの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 - Cryostat
 - Data Grid
 - Grafana Operator (Community)
+- OpenShift Elasticsearch Operator (stable-5.2)
+- Red Hat OpenShift distributed tracing platform
+- Kiali Operator
+- Red Hat OpenShift Service Mesh
 
 # 初期処理
 ```shell

--- a/environment/cleanup.sh
+++ b/environment/cleanup.sh
@@ -1,4 +1,7 @@
-# clean up
+# change project
+oc project red-hat-pay
+
+# clean up resources
 oc delete is,bc,deploy,svc -l app=httpd
 oc delete infinispan example-infinispan
 oc delete cache paymentcachedefinition
@@ -16,7 +19,11 @@ oc delete svc payment
 oc delete svc point
 oc delete route payment
 oc delete grafana example-grafana
-oc delete sa infinispan-monitoring
 oc delete grafanadatasource grafanadatasource
 oc delete grafanadashboard simple-dashboard
 oc delete cryostat cryostat-sample
+oc delete smcp basic -n rhp-istio-system
+oc delete smmr default -n rhp-istio-system
+oc delete gateway redhatpay-gateway
+oc delete virtualservice redhatpay
+oc delete destinationrule payment

--- a/environment/init.sh
+++ b/environment/init.sh
@@ -12,10 +12,10 @@ oc new-project rhp-istio-system
 oc new-project red-hat-pay-monolith
 
 # Enabling monitoring for user-defined projects
+oc project red-hat-pay
 oc apply -f environment/cluster-monitoring-config.yaml
 oc apply -f environment/service-account.yaml
 oc adm policy add-cluster-role-to-user cluster-monitoring-view -z infinispan-monitoring
 oc apply -f environment/service_monitor.yaml
-
 
 echo "Please install some operators such as Data Grid, Cryostat on OpenShift Console"

--- a/environment/init.sh
+++ b/environment/init.sh
@@ -12,10 +12,10 @@ oc new-project rhp-istio-system
 oc new-project red-hat-pay-monolith
 
 # Enabling monitoring for user-defined projects
-oc apply -f cluster-monitoring-config.yaml
-oc apply -f service-account.yaml
+oc apply -f environment/cluster-monitoring-config.yaml
+oc apply -f environment/service-account.yaml
 oc adm policy add-cluster-role-to-user cluster-monitoring-view -z infinispan-monitoring
-oc apply -f service_monitor.yaml
+oc apply -f environment/service_monitor.yaml
 
 
 echo "Please install some operators such as Data Grid, Cryostat on OpenShift Console"

--- a/environment/monolith/README.md
+++ b/environment/monolith/README.md
@@ -1,6 +1,6 @@
 # OpenShift プロジェクト作成
 ```shell
-$ oc new-project monolith
+$ oc new-project red-hat-pay-monolith
 ``` 
 
 # アプリケーションをビルド
@@ -14,4 +14,9 @@ $ bash environment/build/build.sh
 ```shell
 $ cd environment/monolith
 $ bash install.sh
+```
+
+# 環境を削除
+```
+$ bash cleanup.sh
 ```

--- a/environment/monolith/cleanup.sh
+++ b/environment/monolith/cleanup.sh
@@ -1,0 +1,7 @@
+# change project
+oc project red-hat-pay-monolith
+
+# clean up resources
+oc delete secret,svc,pvc,dc -l template=postgresql-persistent-template
+oc delete bc monolith
+oc delete all -l app=monolith

--- a/environment/monolith/install.sh
+++ b/environment/monolith/install.sh
@@ -19,7 +19,3 @@ cd ../environment/monolith/
 oc set resources deploymentconfig postgres --limits=cpu=1,memory=1024Mi --requests=cpu=1,memory=1024Mi
 oc set resources deployment monolith --limits=cpu=1,memory=1024Mi --requests=cpu=1,memory=1024Mi
 
-# clean up
-#oc delete secret,svc,pvc,dc -l template=postgresql-persistent-template
-#oc delete bc monolith
-#oc delete all -l app=monolith

--- a/environment/prod/install.sh
+++ b/environment/prod/install.sh
@@ -40,7 +40,11 @@ oc apply -f servicemesh_memberroll-default.yaml
 oc apply -f servicemesh-gateway.yaml
 oc apply -f servicemesh_destination-rule-all.yaml
 
+# side car container injection
 sleep 30
+oc rollout restart deploy payment
+oc rollout restart deploy point
+
 echo ""
 echo "Please access to http://`oc -n rhp-istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}'`/index"
 

--- a/environment/prod/install.sh
+++ b/environment/prod/install.sh
@@ -40,6 +40,7 @@ oc apply -f servicemesh_memberroll-default.yaml
 oc apply -f servicemesh-gateway.yaml
 oc apply -f servicemesh_destination-rule-all.yaml
 
+sleep 30
 echo ""
 echo "Please access to http://`oc -n rhp-istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}'`/index"
 


### PR DESCRIPTION
インストール関連のスクリプトを実行したところ、いくつかインストールに失敗した箇所が見つかったので、スクリプトの修正と README にサービスメッシュ関連の Operator をインストールするように修正しました。
また、cleanup スクリプトにサービスメッシュ関連リソースの削除を追加したり、モノリス版の cleanup スクリプトを新規作成したりしています。