### PR TITLE
Quarkus のメトリクスを取得できるよう pom.xml を編集

### DIFF
--- a/payment/pom.xml
+++ b/payment/pom.xml
@@ -92,6 +92,10 @@
       <artifactId>opentracing-jdbc</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+  </dependency>
+    <dependency>
       <groupId>rhpay</groupId>
       <artifactId>domain</artifactId>
       <version>1.0-SNAPSHOT</version>

--- a/point/pom.xml
+++ b/point/pom.xml
@@ -69,6 +69,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>rhpay</groupId>
             <artifactId>domain</artifactId>
             <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
以下のドキュメントを参考に、Quarkus のメトリクスを取得できるよう、pom.xml に micrometer-registry-prometheus エクステンションを追加しました。
https://quarkus.io/guides/micrometer#creating-the-maven-project

OpenShift Web コンソールの Metrics から Quarkus のメトリクス (例: http_server_connections_seconds_active_count) が参照できるようになったことを確認しています。