### PR TITLE
ログ集約のため OpenShift Logging のインストール

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Red Hat OpenShift distributed tracing platform
 - Kiali Operator
 - Red Hat OpenShift Service Mesh
+- Red Hat OpenShift Logging (stable-5.2)
 
 # 初期処理
 ```shell

--- a/environment/cluster_logging.yaml
+++ b/environment/cluster_logging.yaml
@@ -1,0 +1,41 @@
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance" 
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"  
+  logStore:
+    type: "elasticsearch"  
+    retentionPolicy: 
+      application:
+        maxAge: 1d
+      infra:
+        maxAge: 7d
+      audit:
+        maxAge: 7d
+    elasticsearch:
+      nodeCount: 3 
+      storage:
+        storageClassName: "gp2" 
+        size: 100G
+      resources: 
+          limits:
+            memory: "4Gi"
+          requests:
+            memory: "4Gi"
+      proxy: 
+        resources:
+          limits:
+            memory: 256Mi
+          requests:
+            memory: 256Mi
+      redundancyPolicy: "SingleRedundancy"
+  visualization:
+    type: "kibana"  
+    kibana:
+      replicas: 1
+  collection:
+    logs:
+      type: "fluentd"  
+      fluentd: {}

--- a/environment/init.sh
+++ b/environment/init.sh
@@ -17,5 +17,6 @@ oc apply -f environment/cluster-monitoring-config.yaml
 oc apply -f environment/service-account.yaml
 oc adm policy add-cluster-role-to-user cluster-monitoring-view -z infinispan-monitoring
 oc apply -f environment/service_monitor.yaml
+oc apply -f environment/cluster_logging.yaml
 
 echo "Please install some operators such as Data Grid, Cryostat on OpenShift Console"


### PR DESCRIPTION
Quarkus アプリケーション・RHDG のログ集約を実現するため OpenShift Logging をインストールするように init.sh の内容などを変更しました。また、OpenShift Logging の Elasticsearch はデフォルトで 16Gi のメモリを要求しますが、プロトタイプなので 4Gi に減らしています。