### PR TITLE
Temp tsasaki 20231029

### DIFF
--- a/payment-wildfly/bin/env.sh
+++ b/payment-wildfly/bin/env.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 scriptDir=$(cd $(dirname $0) && pwd)
+myOcpUser=$(oc whoami)
 
-oc new-project wildfly-sample
+oc new-project wildfly-sample-$myOcpUser
 oc apply -f ${scriptDir}/wildfly.yaml
 sleep 10
 oc exec wildfly-pod -- /opt/jboss/wildfly/bin/add-user.sh user1 secret --silent

--- a/payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceExceptionUTest.java
+++ b/payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceExceptionUTest.java
@@ -73,7 +73,7 @@ public class PaymentResourceExceptionUTest {
         response
                 .then()
                 .assertThat()
-                .statusCode(HttpURLConnection.?);
+                .statusCode(?);
 この行を削除します */
     }
 

--- a/payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceUTest.java
+++ b/payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceUTest.java
@@ -126,7 +126,7 @@ public class PaymentResourceUTest {
                 .then()
                 .assertThat()
                  // HTTPのステータスコードを指定します
-                .statusCode(?)
+                .statusCode(HttpURLConnection.?)
                 // 期待するストアのIDを指定します
                 .body("storeId", is(?))
                 // 期待する買い物客のIDを指定します


### PR DESCRIPTION
Red Hat Sasakiです。

payment-wildfly/bin/env.sh 
: 複数名の同時実施時に後のconnection.shに失敗してしまうので、Namespace分割して各々Wildfly podを立ち上げる形はいかがでしょう？

payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceUTest.java
payment-wildfly/src/test/java/rhpay/payment/rest/PaymentResourceExceptionUTest.java
: Status Codeのチェックを行う際に PaymentResourceUTest.java は数値でもメッセージで見ても良さそうなのですが、PaymentResourceExceptionUTest.java は数値でみないとダメそうなので、課題の指示文を思うとこの形はいかがでしょう？